### PR TITLE
Plugin version 1.0.3 in 'Usage' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This sbt plugin provides a customizable release process that you can add to your
 
 Add the following lines to `./project/plugins.sbt`. See the section [Using Plugins](http://www.scala-sbt.org/release/tutorial/Using-Plugins.html) in the sbt wiki for more information.
 
-    addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.2")
+    addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
 ## version.sbt
 


### PR DESCRIPTION
Valid version numbers in 'Requirements' section contains example of pre-release with dots. 
Support for it added in 1.0.3, while 'Usage' section still suggests to use 1.0.2